### PR TITLE
PubSubClient locked to 2.7

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,4 +22,4 @@ lib_deps =
   ArduinoJson
   Adafruit Unified Sensor
   DHT sensor library
-  PubSubClient
+  PubSubClient@2.7


### PR DESCRIPTION
PubSubClient locked to 2.7 since 2.8 doesn't work with current code